### PR TITLE
Add cordova build config to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,11 @@
 # Mac OS
 .DS_Store
 mobile/node_modules
+mobile/platforms/android/
+mobile/plugins/android.json
+mobile/plugins/cordova-plugin-camera/
+mobile/plugins/cordova-plugin-file-transfer/
+mobile/plugins/cordova-plugin-file/
 server/node_modules
+server/.env
+


### PR DESCRIPTION
Do not check in cordova build artifacts for platform
and plugins to the git repo.