### PR TITLE
Remove deprecated metrics-tracker.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 [![Build Status](https://travis-ci.org/IBM/watson-vehicle-damage-analyzer.svg?branch=master)](https://travis-ci.org/IBM/watson-vehicle-damage-analyzer)
-![IBM Cloud Deployments](https://metrics-tracker.mybluemix.net/stats/8ef3c79f843535f3cff63dba2b4d7ac5/badge.svg)
 
 # Create a custom Visual Recognition classifier for analyzing vehicle damage
 
@@ -43,7 +42,7 @@ This code pattern contains several pieces. The app server communicates with the 
 
 ## Deploy the Server Application to IBM Cloud
 
-[![Deploy to IBM Cloud](https://metrics-tracker.mybluemix.net/stats/8ef3c79f843535f3cff63dba2b4d7ac5/button.svg)](https://bluemix.net/deploy?repository=https://github.com/IBM/watson-vehicle-damage-analyzer)
+[![Deploy to IBM Cloud](https://bluemix.net/deploy/button.png)](https://bluemix.net/deploy?repository=https://github.com/IBM/watson-vehicle-damage-analyzer)
 
 1. Press the above ``Deploy to IBM Cloud`` button and then click on ``Deploy`` and then jump to step #5.
 
@@ -359,28 +358,6 @@ Finished: FAILED
 ![App not running](doc/source/images/app-not-running.png)
 
 > Both of these can be spurious errors. Click the `Visit App URL` link in the IBM Cloud console, or try `Runtime` -> `SSH`, or simply test the app to see if it is running.
-
-# Privacy Notice
-
-If using the Deploy to IBM Cloud button some metrics are tracked, the following information is sent to a [Metrics Tracker](https://github.com/IBM/metrics-collector-service) service on each deployment:
-
-* Node.js package version
-* Node.js repository URL
-* Application Name (`application_name`)
-* Application GUID (`application_id`)
-* Application instance index number (`instance_index`)
-* Space ID (`space_id`)
-* Application Version (`application_version`)
-* Application URIs (`application_uris`)
-* Cloud Foundry API (`cf_api`)
-* Labels of bound services
-* Number of instances for each bound service and associated plan information
-
-This data is collected from the `package.json` and `repository.yaml` files in the sample application and the ``VCAP_APPLICATION`` and ``VCAP_SERVICES`` environment variables in IBM Cloud and other Cloud Foundry platforms. This data is used by IBM to track metrics around deployments of sample applications to IBM Cloud to measure the usefulness of our examples, so that we can continuously improve the content we offer to you. Only deployments of sample applications that include code to ping the Metrics Tracker service will be tracked.
-
-## Disabling Deployment Tracking
-
-To disable tracking, simply remove `require("metrics-tracker-client").track();` from the [server/app.js](server/app.js) file.
 
 # Links
 * [Demo on Youtube](https://youtu.be/rVL1HsbsdBI)

--- a/server/app.js
+++ b/server/app.js
@@ -106,4 +106,3 @@ const port = process.env.PORT || process.env.VCAP_APP_PORT || 3000;
 application.listen(port, function () {
     console.log("Server running on port: %d", port);
 });
-require('metrics-tracker-client').track();

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -2102,53 +2102,6 @@
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
       "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
     },
-    "metrics-tracker-client": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/metrics-tracker-client/-/metrics-tracker-client-0.2.3.tgz",
-      "integrity": "sha1-aFvaFeNTzTdnokzTOTbE2dBaNJg=",
-      "requires": {
-        "cwd": "0.10.0",
-        "js-yaml": "3.10.0",
-        "restler": "3.4.0"
-      },
-      "dependencies": {
-        "esprima": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-          "integrity": "sha1-RJnt3NERDgshi6zy+n9/WfVcqAQ="
-        },
-        "iconv-lite": {
-          "version": "0.2.11",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz",
-          "integrity": "sha1-HOYKOleGSiktEyH/RgnKS7llrcg="
-        },
-        "js-yaml": {
-          "version": "3.10.0",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
-          "integrity": "sha1-LnhEFka9RoLpY/IrbpKCPDCcYtw=",
-          "requires": {
-            "argparse": "1.0.9",
-            "esprima": "4.0.0"
-          }
-        },
-        "qs": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-1.2.0.tgz",
-          "integrity": "sha1-7Qeb4oaCFH5v2aNMwrDB4OxkU+4="
-        },
-        "restler": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/restler/-/restler-3.4.0.tgz",
-          "integrity": "sha1-dB7As9FrlJ/uooE9DDxoUp6IjZs=",
-          "requires": {
-            "iconv-lite": "0.2.11",
-            "qs": "1.2.0",
-            "xml2js": "0.4.0",
-            "yaml": "0.2.3"
-          }
-        }
-      }
-    },
     "mime": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",

--- a/server/package.json
+++ b/server/package.json
@@ -24,7 +24,6 @@
     "dotenv": "^4.0.0",
     "express": "^4.15.x",
     "formidable": "*",
-    "metrics-tracker-client": "*",
     "vcap_services": "^0.2.0",
     "watson-developer-cloud": "^2.0.3"
   },


### PR DESCRIPTION
Remove:
Badge at top of README
Privacy Notice from Readme
Disabling Deployment Tracking from Readme
use of metric tracker in app:
i.e. `require('metrics-tracker-client').track();`
package.json for metrics-tracker
package-lock.json stuff

Change D2B to:
https://bluemix.net/deploy/button.png