### PR TITLE
Change free to lite in manifest.yml

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -2,7 +2,7 @@
 declared-services:
   wvda-visual-recognition:
     label: watson_vision_combined
-    plan: free
+    plan: lite
 applications:
 - path: ./server
   memory: 256M


### PR DESCRIPTION
The name of the `free` tier for Visual Recognition has changed to
`lite`.

Closes: #47
Closes: #50